### PR TITLE
Initial working version of vcloud-disk_launcher

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+*.gem
+*.rbc
+/.bundle/
+/.ruby-version
+/Gemfile.lock
+/coverage/
+/pkg/
+fog_integration_test.config
+/spec/integration/vcloud_tools_testing_config.yaml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+## 0.1.0 (2014-11-28)
+
+Features:
+
+  - Initial version
+  - Allows creation of vCD 'Independent Disks', via a YAML file in the same style
+    as vcloud-launcher.

--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,12 @@ source 'https://rubygems.org'
 
 gemspec
 
+if ENV['VCLOUD_TOOLS_TESTER_DEV_MASTER']
+  gem 'vcloud-tools-tester', :git => 'git@github.com:gds-operations/vcloud-tools-tester.git', :branch => 'master'
+elsif ENV['VCLOUD_TOOLS_TESTER_LOCAL']
+  gem 'vcloud-tools-tester', :path => '../vcloud-tools-tester'
+end
+
 if ENV['VCLOUD_CORE_DEV_MASTER']
   gem 'vcloud-core', :git => 'git@github.com:gds-operations/vcloud-core.git', :branch => 'master'
 elsif ENV['VCLOUD_CORE_DEV_LOCAL']

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,9 @@
+source 'https://rubygems.org'
+
+gemspec
+
+if ENV['VCLOUD_CORE_DEV_MASTER']
+  gem 'vcloud-core', :git => 'git@github.com:gds-operations/vcloud-core.git', :branch => 'master'
+elsif ENV['VCLOUD_CORE_DEV_LOCAL']
+  gem 'vcloud-core', :path => '../vcloud-core'
+end

--- a/README.md
+++ b/README.md
@@ -1,4 +1,92 @@
 vCloud Disk Launcher
 ====================
 
+A tool that takes a YAML or JSON configuration file describing a list of
+Independent Disks in a vCloud Director Organisation, and provisions them
+as needed.
 
+### Supports
+
+- Configuration of multiple Independent Disks with:
+  - custom name
+  - custom size
+- Basic idempotent operation - disks that already exist are skipped.
+- Adds helper code to prevent creation of disks with the same name.
+
+### Limitations
+
+- Does not yet support configuration of the storage profile of an independent
+  disk. The default storage profile for the vDC is used.
+
+## Installation
+
+Add this line to your application's Gemfile:
+
+    gem 'vcloud-disk_launcher'
+
+And then execute:
+
+    $ bundle
+
+Or install it yourself as:
+
+    $ gem install vcloud-disk_launcher
+
+
+## Usage
+
+`vcloud-disk_launch disk_list.yaml`
+
+## Configuration schemas
+
+Configuration schemas can be found in [`lib/vcloud/disk_launcher/schema/`][schema].
+
+[schema]: /lib/vcloud/disk_launcher/schema
+
+## Credentials
+
+Please see the [vcloud-tools usage documentation](http://gds-operations.github.io/vcloud-tools/usage/).
+
+## Contributing
+
+1. Fork it
+2. Create your feature branch (`git checkout -b my-new-feature`)
+3. Commit your changes (`git commit -am 'Add some feature'`)
+4. Push to the branch (`git push origin my-new-feature`)
+5. Create new Pull Request
+
+## Other settings
+
+vCloud Disk Launcher uses vCloud Core. If you want to use the latest version of
+vCloud Core, or a local version, you can export some variables. See the Gemfile
+for details.
+
+## The vCloud API
+
+vCloud Tools currently use version 5.1 of the [vCloud API](http://pubs.vmware.com/vcd-51/index.jsp?topic=%2Fcom.vmware.vcloud.api.doc_51%2FGUID-F4BF9D5D-EF66-4D36-A6EB-2086703F6E37.html). Version 5.5 may work but is not currently supported. You should be able to access the 5.1 API in a 5.5 environment, and this *is* currently supported.
+
+The default version is defined in [Fog](https://github.com/fog/fog/blob/244a049918604eadbcebd3a8eaaf433424fe4617/lib/fog/vcloud_director/compute.rb#L32).
+
+If you want to be sure you are pinning to 5.1, or use 5.5, you can set the API version to use in your fog file, e.g.
+
+`vcloud_director_api_version: 5.1`
+
+## Debugging
+
+`export EXCON_DEBUG=true` - this will print out the API requests and responses.
+
+`export DEBUG=true` - this will show you the stack trace when there is an exception instead of just the message.
+
+## Testing
+
+Run the default suite of tests (e.g. lint, unit, features):
+
+    bundle exec rake
+
+Run the integration tests (slower and requires a real environment):
+
+    bundle exec rake integration
+
+You need access to a suitable vCloud Director organization to run the
+integration tests. See the [integration tests README](/spec/integration/README.md) for
+further details.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
-vcloud-disk-launcher
+vCloud Disk Launcher
 ====================
+
+

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,26 @@
+require 'rspec/core/rake_task'
+require 'gem_publisher'
+
+task :default => [:rubocop, :spec]
+
+RSpec::Core::RakeTask.new(:spec) do |task|
+  # Set a bogus Fog credential, otherwise it's possible for the unit
+  # tests to accidentially run (and succeed against!) an actual 
+  # environment, if Fog connection is not stubbed correctly.
+  ENV['FOG_CREDENTIAL'] = 'random_nonsense_owiejfoweijf'
+  task.pattern = FileList['spec/vcloud/**/*_spec.rb']
+end
+
+RSpec::Core::RakeTask.new(:integration) do |t|
+  t.pattern = FileList['spec/integration/**/*_spec.rb']
+end
+
+task :publish_gem do
+  gem = GemPublisher.publish_if_updated("vcloud-disk_launcher.gemspec", :rubygems)
+  puts "Published #{gem}" if gem
+end
+
+require 'rubocop/rake_task'
+RuboCop::RakeTask.new(:rubocop) do |task|
+  task.options = ['--lint']
+end

--- a/bin/vcloud-disk-launch
+++ b/bin/vcloud-disk-launch
@@ -1,0 +1,5 @@
+#!/usr/bin/env ruby
+
+require 'vcloud/disk_launcher'
+
+Vcloud::DiskLauncher::Cli.new(ARGV).run

--- a/lib/vcloud/disk_launcher.rb
+++ b/lib/vcloud/disk_launcher.rb
@@ -1,0 +1,12 @@
+require 'rubygems'
+require 'bundler/setup'
+require 'json'
+require 'yaml'
+require 'csv'
+require 'open3'
+require 'pp'
+
+require 'vcloud/disk_launcher/version'
+
+require 'vcloud/core'
+

--- a/lib/vcloud/disk_launcher.rb
+++ b/lib/vcloud/disk_launcher.rb
@@ -10,3 +10,7 @@ require 'vcloud/disk_launcher/version'
 
 require 'vcloud/core'
 
+require 'vcloud/disk_launcher/schema/disk_launch'
+require 'vcloud/disk_launcher/disk_launch'
+require 'vcloud/disk_launcher/cli'
+

--- a/lib/vcloud/disk_launcher/cli.rb
+++ b/lib/vcloud/disk_launcher/cli.rb
@@ -1,0 +1,89 @@
+require 'optparse'
+
+module Vcloud
+  module DiskLauncher
+    class Cli
+
+      # Initiates parsing of the command-line arguments.
+      #
+      # @param  argv_array [Array] Command-line arguments
+      # @return [void]
+      def initialize(argv_array)
+        @usage_text = nil
+        @config_file = nil
+
+        parse(argv_array)
+      end
+
+      # Runs +Vcloud::DiskLauncher::DiskLaunch#run+ to create independent disks defined
+      # in +@config_file+, catching any exceptions to prevent printing a backtrace.
+      #
+      # @return [void]
+      def run
+        begin
+          Vcloud::DiskLauncher::DiskLaunch.new.run(@config_file)
+        rescue => error_msg
+          $stderr.puts(error_msg)
+          exit 1
+        end
+      end
+
+      private
+
+      def parse(args)
+        opt_parser = OptionParser.new do |opts|
+          examples_dir = File.absolute_path(
+            File.join(
+              File.dirname(__FILE__),
+              "..",
+              "..",
+              "..",
+              "examples",
+              File.basename($0),
+            ))
+
+          opts.banner = <<-EOS
+Usage: #{$0} [options] config_file
+
+vcloud-disk-launch takes a configuration describing a list of Independent Disks in a vCloud Org
+and tries to make it a reality.
+
+See https://github.com/gds-operations/vcloud-tools for more info
+
+Example configuration files can be found in:
+  #{examples_dir}
+          EOS
+
+          opts.separator ""
+          opts.separator "Options:"
+
+          opts.on("-h", "--help", "Print usage and exit") do
+            $stderr.puts opts
+            exit
+          end
+
+          opts.on("--version", "Display version and exit") do
+            puts Vcloud::DiskLauncher::VERSION
+            exit
+          end
+        end
+
+        @usage_text = opt_parser.to_s
+        begin
+          opt_parser.parse!(args)
+        rescue OptionParser::InvalidOption => e
+          exit_error_usage(e)
+        end
+
+        exit_error_usage("must supply config_file") unless args.size == 1
+        @config_file = args.first
+      end
+
+      def exit_error_usage(error)
+        $stderr.puts "#{$0}: #{error}"
+        $stderr.puts @usage_text
+        exit 2
+      end
+    end
+  end
+end

--- a/lib/vcloud/disk_launcher/disk_launch.rb
+++ b/lib/vcloud/disk_launcher/disk_launch.rb
@@ -1,0 +1,26 @@
+module Vcloud
+  module DiskLauncher
+    class DiskLaunch
+
+      # Initializes instance variables.
+      #
+      # @return [void]
+      def initialize
+        @config_loader = Vcloud::Core::ConfigLoader.new
+      end
+
+      # Parses a configuration file and provisions the networks it defines.
+      #
+      # @param  config_file [String]  Path to a YAML or JSON-formatted configuration file
+      # @return [void]
+      def run(config_file = nil)
+        config = @config_loader.load_config(config_file, Vcloud::DiskLauncher::Schema::DISK_LAUNCH)
+
+        config[:disks].each do |disk_config|
+          puts disk_config
+        end
+
+      end
+    end
+  end
+end

--- a/lib/vcloud/disk_launcher/disk_launch.rb
+++ b/lib/vcloud/disk_launcher/disk_launch.rb
@@ -17,10 +17,23 @@ module Vcloud
         config = @config_loader.load_config(config_file, Vcloud::DiskLauncher::Schema::DISK_LAUNCH)
 
         config[:independent_disks].each do |disk_config|
-          Vcloud::Core::IndependentDisk.create(
-            Vcloud::Core::Vdc.get_by_name(disk_config[:vdc_name]),
-            disk_config[:name],
-            disk_config[:size]
+          name = disk_config[:name]
+          vdc_name = disk_config[:vdc_name]
+          size = disk_config[:size]
+          begin
+            disk = Vcloud::Core::IndependentDisk.create(
+              Vcloud::Core::Vdc.get_by_name(vdc_name),
+              name,
+              size
+            )
+          rescue Vcloud::Core::IndependentDisk::DiskAlreadyExistsException
+            Vcloud::Core.logger.info(
+              "Disk '#{name}' already exists in vDC '#{vdc_name}'. Skipping"
+            )
+            next
+          end
+          Vcloud::Core.logger.info(
+            "Created disk '#{name}' in vDC #{vdc_name} successfully. (id: #{disk.id})"
           )
         end
 

--- a/lib/vcloud/disk_launcher/disk_launch.rb
+++ b/lib/vcloud/disk_launcher/disk_launch.rb
@@ -16,7 +16,7 @@ module Vcloud
       def run(config_file = nil)
         config = @config_loader.load_config(config_file, Vcloud::DiskLauncher::Schema::DISK_LAUNCH)
 
-        config[:disks].each do |disk_config|
+        config[:independent_disks].each do |disk_config|
           puts disk_config
         end
 

--- a/lib/vcloud/disk_launcher/disk_launch.rb
+++ b/lib/vcloud/disk_launcher/disk_launch.rb
@@ -17,7 +17,11 @@ module Vcloud
         config = @config_loader.load_config(config_file, Vcloud::DiskLauncher::Schema::DISK_LAUNCH)
 
         config[:independent_disks].each do |disk_config|
-          puts disk_config
+          Vcloud::Core::IndependentDisk.create(
+            Vcloud::Core::Vdc.get_by_name(disk_config[:vdc_name]),
+            disk_config[:name],
+            disk_config[:size]
+          )
         end
 
       end

--- a/lib/vcloud/disk_launcher/schema/disk_launch.rb
+++ b/lib/vcloud/disk_launcher/schema/disk_launch.rb
@@ -2,7 +2,33 @@ module Vcloud
   module DiskLauncher
     module Schema
 
-      DISK_LAUNCH = { }
+      DISK_LAUNCH = {
+        type: 'hash',
+        internals: {
+          independent_disks: {
+            type: 'array',
+            required: true,
+            allowed_empty: true,
+            each_element_is: {
+              type: 'hash',
+              internals: {
+                name: {
+                  type: 'string',
+                  required: true,
+                },
+                vdc_name: {
+                  type: 'string',
+                  required: true,
+                },
+                size: {
+                  type: 'string',
+                  required: true,
+                },
+              },
+            },
+          },
+        },
+      }
 
     end
   end

--- a/lib/vcloud/disk_launcher/schema/disk_launch.rb
+++ b/lib/vcloud/disk_launcher/schema/disk_launch.rb
@@ -1,0 +1,9 @@
+module Vcloud
+  module DiskLauncher
+    module Schema
+
+      DISK_LAUNCH = { }
+
+    end
+  end
+end

--- a/lib/vcloud/disk_launcher/version.rb
+++ b/lib/vcloud/disk_launcher/version.rb
@@ -1,0 +1,5 @@
+module Vcloud
+  module DiskLauncher
+    VERSION = '0.1.0'
+  end
+end

--- a/spec/erb_helper.rb
+++ b/spec/erb_helper.rb
@@ -1,0 +1,11 @@
+class ErbHelper
+  def self.convert_erb_template_to_yaml test_namespace, input_erb_config
+    input_erb_config = input_erb_config
+    e = ERB.new(File.open(input_erb_config).read)
+    output_yaml_config = File.join(File.dirname(input_erb_config), "output_#{Time.now.strftime('%s')}.yaml")
+    File.open(output_yaml_config, 'w') { |f|
+      f.write e.result(OpenStruct.new(test_namespace).instance_eval { binding })
+    }
+    output_yaml_config
+  end
+end

--- a/spec/integration/disk_launcher/data/single_disk.yaml.erb
+++ b/spec/integration/disk_launcher/data/single_disk.yaml.erb
@@ -1,0 +1,4 @@
+independent_disks:
+  - name: <%= disk_name %>
+    vdc_name: <%= vdc_1_name %>
+    size: 100MB

--- a/spec/integration/disk_launcher/disk_launch_spec.rb
+++ b/spec/integration/disk_launcher/disk_launch_spec.rb
@@ -1,0 +1,63 @@
+require 'spec_helper'
+require 'pp'
+require 'erb'
+require 'ostruct'
+require 'vcloud/tools/tester'
+
+describe Vcloud::DiskLauncher::DiskLaunch do
+  context "with minimum input setup" do
+
+    before(:all) do
+      @disks_to_delete = []
+      @files_to_delete = []
+    end
+
+    it "should create a single disk" do
+      test_data_1 = define_test_data
+      minimum_data_erb = File.join(File.dirname(__FILE__), 'data/single_disk.yaml.erb')
+      minimum_data_yaml = ErbHelper.convert_erb_template_to_yaml(test_data_1, minimum_data_erb)
+      @files_to_delete.push(minimum_data_yaml)
+      Vcloud::DiskLauncher::DiskLaunch.new.run(minimum_data_yaml)
+
+      created_disk = Vcloud::Core::IndependentDisk.get_by_name_and_vdc_name(
+        test_data_1[:disk_name],
+        test_data_1[:vdc_1_name]
+      )
+      @disks_to_delete.push(created_disk)
+
+      expect(created_disk).not_to be_nil
+      expect(created_disk.name).to eq(test_data_1[:disk_name])
+    end
+
+    after(:all) do
+      unless ENV['VCLOUD_TOOLS_RSPEC_NO_DELETE']
+        @files_to_delete.each do |file|
+          File.delete file
+        end
+        @disks_to_delete.each do |disk|
+          disk.destroy
+        end
+      end
+    end
+
+  end
+
+  def define_test_data
+
+    config_file = File.join(File.dirname(__FILE__),
+      "../vcloud_tools_testing_config.yaml")
+    required_user_params = [
+      "vdc_1_name",
+      "vdc_2_name",
+    ]
+    parameters = Vcloud::Tools::Tester::TestSetup.new(config_file, required_user_params).test_params
+
+    {
+      disk_name: "vcloud-disk_launcher-tests-#{Time.now.strftime('%s')}",
+      vdc_1_name: parameters.vdc_1_name,
+      vdc_2_name: parameters.vdc_2_name,
+    }
+
+  end
+
+end

--- a/spec/integration/vcloud_tools_testing_config.yaml.template
+++ b/spec/integration/vcloud_tools_testing_config.yaml.template
@@ -1,0 +1,3 @@
+default:
+  vdc_1_name:
+  vdc_2_name:

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,31 @@
+# SimpleCov must run _first_ according to its README
+if ENV['COVERAGE']
+  require 'simplecov'
+
+  # monkey-patch to prevent SimpleCov from reporting coverage percentage
+  class SimpleCov::Formatter::HTMLFormatter
+    def output_message(_message)
+      nil
+    end
+  end
+
+  SimpleCov.adapters.define 'gem' do
+    add_filter '/spec/'
+    add_filter '/features/'
+    add_filter '/vendor/'
+
+    add_group 'Libraries', '/lib/'
+  end
+
+  SimpleCov.minimum_coverage(99)
+  SimpleCov.start 'gem'
+end
+
+require 'erb_helper'
+require 'vcloud/disk_launcher'
+
+RSpec.configure do |config|
+  config.expect_with :rspec do |c|
+    c.syntax = :expect
+  end
+end

--- a/spec/vcloud/disk_launcher/cli_spec.rb
+++ b/spec/vcloud/disk_launcher/cli_spec.rb
@@ -1,0 +1,137 @@
+require 'spec_helper'
+
+class CommandRun
+  attr_accessor :stdout, :stderr, :exitstatus
+
+  def initialize(args)
+    out = StringIO.new
+    err = StringIO.new
+
+    $stdout = out
+    $stderr = err
+
+    begin
+      Vcloud::DiskLauncher::Cli.new(args).run
+      @exitstatus = 0
+    rescue SystemExit => e
+      # Capture exit(n) value.
+      @exitstatus = e.status
+    end
+
+    @stdout = out.string.strip
+    @stderr = err.string.strip
+
+    $stdout = STDOUT
+    $stderr = STDERR
+  end
+end
+
+describe Vcloud::DiskLauncher::Cli do
+  subject { CommandRun.new(args) }
+
+  let(:mock_disk_launch) {
+    double(:disk_launch, :run => true)
+  }
+  let(:config_file) { 'config.yaml' }
+
+  describe "under normal usage" do
+    shared_examples "a good CLI command" do
+      it "passes the right CLI options and exits normally" do
+        expect(Vcloud::DiskLauncher::DiskLaunch).to receive(:new).
+          and_return(mock_disk_launch)
+        expect(mock_disk_launch).to receive(:run).
+          with(config_file)
+        expect(subject.exitstatus).to eq(0)
+      end
+    end
+
+    context "when given a single config file" do
+      let(:args) { [ config_file ] }
+
+      it_behaves_like "a good CLI command"
+    end
+
+    context "when asked to display version" do
+      let(:args) { %w{--version} }
+
+      it "does not call DiskLaunch" do
+        expect(Vcloud::DiskLauncher::DiskLaunch).not_to receive(:new)
+      end
+
+      it "prints version and exits normally" do
+        expect(subject.stdout).to eq(Vcloud::DiskLauncher::VERSION)
+        expect(subject.exitstatus).to eq(0)
+      end
+    end
+
+    context "when asked to display help" do
+      let(:args) { %w{--help} }
+
+      it "does not call DiskLaunch" do
+        expect(Vcloud::DiskLauncher::DiskLaunch).not_to receive(:new)
+      end
+
+      it "prints usage and exits normally" do
+        expect(subject.stderr).to match(/\AUsage: \S+ \[options\] config_file\n/)
+        expect(subject.exitstatus).to eq(0)
+      end
+    end
+  end
+
+  describe "incorrect usage" do
+    shared_examples "print usage and exit abnormally" do |error|
+      it "does not call DiskLaunch" do
+        expect(Vcloud::DiskLauncher::DiskLaunch).not_to receive(:new)
+      end
+
+      it "prints error message and usage" do
+        expect(subject.stderr).to match(/\A\S+: #{error}\nUsage: \S+/)
+      end
+
+      it "exits abnormally for incorrect usage" do
+        expect(subject.exitstatus).to eq(2)
+      end
+    end
+
+    context "when run without any arguments" do
+      let(:args) { %w{} }
+
+      it_behaves_like "print usage and exit abnormally", "must supply config_file"
+    end
+
+    context "when given multiple config files" do
+      let(:args) { %w{one.yaml two.yaml} }
+
+      it_behaves_like "print usage and exit abnormally", "must supply config_file"
+    end
+
+    context "when given an unrecognised argument" do
+      let(:args) { %w{--this-is-garbage} }
+
+      it_behaves_like "print usage and exit abnormally", "invalid option: --this-is-garbage"
+    end
+  end
+
+  describe "error handling" do
+    context "when underlying code raises an exception" do
+      let(:args) { %w{test.yaml} }
+
+      it "should print error without backtrace and exit abnormally" do
+        expect(Vcloud::DiskLauncher::DiskLaunch).to receive(:new).
+          and_raise("something went horribly wrong")
+        expect(subject.stderr).to eq("something went horribly wrong")
+        expect(subject.exitstatus).to eq(1)
+      end
+    end
+
+    context "when passed an non-existent configuration file" do
+      let(:args) { %w{non-existent.yaml} }
+
+      it "raises a descriptive error" do
+        # Use a regex match as a workaround to https://bugs.ruby-lang.org/issues/9285
+        expect(subject.stderr).to match(/\ANo such file or directory/)
+        expect(subject.exitstatus).to eq(1)
+      end
+    end
+  end
+end

--- a/spec/vcloud/disk_launcher/disk_launch_schema_spec.rb
+++ b/spec/vcloud/disk_launcher/disk_launch_schema_spec.rb
@@ -1,0 +1,61 @@
+require 'spec_helper'
+
+describe Vcloud::DiskLauncher do
+
+  context "DiskLaunch schema validation" do
+
+    it "validates a legal minimal schema" do
+      test_config = {
+        :independent_disks => [
+          :name     =>  "Valid disk name",
+          :vdc_name =>  "Some vDC",
+          :size     =>  "10GB"
+        ]
+      }
+      validator = Vcloud::Core::ConfigValidator.validate(:base, test_config, Vcloud::DiskLauncher::Schema::DISK_LAUNCH)
+      expect(validator.valid?).to be_true
+      expect(validator.errors).to be_empty
+    end
+
+    it "validates a multiple disks" do
+      test_config = {
+        :independent_disks => [
+          {
+            :name     =>  "Valid disk 1",
+            :vdc_name =>  "Some vDC",
+            :size     =>  "10GB"
+          },
+          {
+            :name     =>  "Valid disk 2",
+            :vdc_name =>  "Another vDC",
+            :size     =>  "500MB"
+          },
+        ]
+      }
+      validator = Vcloud::Core::ConfigValidator.validate(:base, test_config, Vcloud::DiskLauncher::Schema::DISK_LAUNCH)
+      expect(validator.valid?).to be_true
+      expect(validator.errors).to be_empty
+    end
+
+    it "validates an empty disk list" do
+      test_config = {
+        :independent_disks => []
+      }
+      validator = Vcloud::Core::ConfigValidator.validate(:base, test_config, Vcloud::DiskLauncher::Schema::DISK_LAUNCH)
+      expect(validator.valid?).to be_true
+      expect(validator.errors).to be_empty
+    end
+
+    it "does not validate an illegal schema" do
+      test_config = {
+        :no_disks_here => {
+          :name => "I am not valid"
+        }
+      }
+      validator = Vcloud::Core::ConfigValidator.validate(:base, test_config, Vcloud::DiskLauncher::Schema::DISK_LAUNCH)
+      expect(validator.valid?).to be_false
+      expect(validator.errors).to eq(["base: parameter 'no_disks_here' is invalid", "base: missing 'independent_disks' parameter"])
+    end
+
+  end
+end

--- a/spec/vcloud/disk_launcher/disk_launch_spec.rb
+++ b/spec/vcloud/disk_launcher/disk_launch_spec.rb
@@ -1,0 +1,43 @@
+require 'spec_helper'
+
+describe Vcloud::DiskLauncher::DiskLaunch do
+
+  context "ConfigLoader returns two different disks" do
+    let(:disk1) {
+      {
+        :name         => 'Test Disk 1',
+        :vdc_name     => 'TestVDC 1',
+        :size         => '500MB',
+      }
+    }
+    let(:disk2) {
+      {
+        :name         => 'Test Disk 2',
+        :vdc_name     => 'TestVDC 2',
+        :size         => '10GiB',
+      }
+    }
+    let(:mock_vdc_1) { double(:mock_vdc, :name => "TestVDC 1") }
+    let(:mock_vdc_2) { double(:mock_vdc, :name => "TestVDC 2") }
+
+    before(:each) do
+      config_loader = double(:config_loader)
+      expect(Vcloud::Core::Vdc).to receive(:get_by_name).with("TestVDC 1").and_return(mock_vdc_1)
+      expect(Vcloud::Core::Vdc).to receive(:get_by_name).with("TestVDC 2").and_return(mock_vdc_2)
+      expect(Vcloud::Core::ConfigLoader).to receive(:new).and_return(config_loader)
+      expect(config_loader).to receive(:load_config).and_return({
+        :independent_disks => [disk1, disk2]
+      })
+    end
+
+    it "should call Core::IndependentDisk.create once for each disk" do
+      expect(Vcloud::Core::IndependentDisk).
+        to receive(:create).with(mock_vdc_1, disk1[:name], disk1[:size])
+      expect(Vcloud::Core::IndependentDisk).
+        to receive(:create).with(mock_vdc_2, disk2[:name], disk2[:size])
+      subject.run('input_config_yaml')
+    end
+
+  end
+
+end

--- a/vcloud-disk_launcher.gemspec
+++ b/vcloud-disk_launcher.gemspec
@@ -1,0 +1,36 @@
+# -*- encoding: utf-8 -*-
+
+lib = File.expand_path('../lib/', __FILE__)
+$LOAD_PATH.unshift lib unless $LOAD_PATH.include?(lib)
+
+require 'vcloud/disk_launcher/version'
+
+Gem::Specification.new do |s|
+  s.name        = 'vcloud-disk_launcher'
+  s.version     = Vcloud::DiskLauncher::VERSION
+  s.authors     = ['Mike Pountney']
+  s.email       = ['Mike.Pountney@gmail.com']
+  s.summary     = 'Tool to launch and configure vCloud Independent Disks'
+  s.description = 'Tool to launch and configure vCloud Independent Disks. Uses vcloud-core.'
+  s.homepage    = 'http://github.com/alphagov/vcloud-disk_launcher'
+  s.license     = 'MIT'
+
+  s.files         = `git ls-files`.split($/)
+  s.executables   = s.files.grep(%r{^bin/}) {|f| File.basename(f)}
+  s.test_files    = s.files.grep(%r{^(test|spec|features)/})
+  s.require_paths = ['lib']
+
+  s.required_ruby_version = '>= 1.9.3'
+
+  s.add_runtime_dependency 'vcloud-core', '~> 0.12.0'
+  s.add_development_dependency 'gem_publisher', '1.2.0'
+  s.add_development_dependency 'pry'
+  s.add_development_dependency 'rake'
+  s.add_development_dependency 'rspec', '~> 2.14.1'
+  s.add_development_dependency 'rubocop', '~> 0.23.0'
+  # Pin SimpleCov to < 0.8.x until this issue is resolved:
+  # https://github.com/colszowka/simplecov/issues/281
+  s.add_development_dependency 'simplecov', '~> 0.7.1'
+  s.add_development_dependency 'vcloud-tools-tester', '~> 0.2.0'
+end
+

--- a/vcloud-disk_launcher.gemspec
+++ b/vcloud-disk_launcher.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 1.9.3'
 
-  s.add_runtime_dependency 'vcloud-core', '~> 0.12.0'
+  s.add_runtime_dependency 'vcloud-core', '~> 0.15.0'
   s.add_development_dependency 'gem_publisher', '1.2.0'
   s.add_development_dependency 'pry'
   s.add_development_dependency 'rake'

--- a/vcloud-disk_launcher.gemspec
+++ b/vcloud-disk_launcher.gemspec
@@ -31,6 +31,6 @@ Gem::Specification.new do |s|
   # Pin SimpleCov to < 0.8.x until this issue is resolved:
   # https://github.com/colszowka/simplecov/issues/281
   s.add_development_dependency 'simplecov', '~> 0.7.1'
-  s.add_development_dependency 'vcloud-tools-tester', '~> 0.2.0'
+  s.add_development_dependency 'vcloud-tools-tester', '~> 0.3.0'
 end
 


### PR DESCRIPTION
As per the README:
# vCloud Disk Launcher

A tool that takes a YAML or JSON configuration file describing a list of
Independent Disks in a vCloud Director Organisation, and provisions them
as needed.
### Supports
- Configuration of multiple Independent Disks with:
  - custom name
  - custom size
- Basic idempotent operation - disks that already exist are skipped.
- Adds helper code to prevent creation of disks with the same name.
### Limitations
- Does not yet support configuration of the storage profile of an independent
  disk. The default storage profile for the vDC is used.
